### PR TITLE
Add custom 404 page for GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page Not Found</title>
+    <link rel="stylesheet" href="styles/styles.css">
+</head>
+<body>
+<div class="wrapper">
+    <div id="container">
+        <main id="main-content">
+            <h1>Page Not Found</h1>
+            <p>The page you're looking for doesn't exist.</p>
+            <p><a href="index.html">Return to Home</a></p>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -1,4 +1,25 @@
 'use strict';
+// Redirect to custom 404 page for invalid routes
+document.addEventListener("DOMContentLoaded", () => {
+    const validRoutes = [
+        "",
+        "index.html",
+        "projects.html",
+        "publications.html",
+        "resume.html",
+        "writings.html",
+        "projects/Ostium.html",
+        "projects/Torrentem.html",
+        "projects/Vadum.html",
+        "writings/numerical_modelling_of_photopolymerization.html",
+        "404.html"
+    ];
+    let path = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');
+    if (!validRoutes.includes(path)) {
+        window.location.replace("/404.html");
+    }
+});
+
 
 // Constants for GitHub API
 const GITHUB_USERNAME = 'Adam-R-Lawrence'; // Replace with your GitHub username


### PR DESCRIPTION
## Summary
- add `404.html` with a friendly message and home link
- ensure GitHub Pages serves static files by adding `.nojekyll`
- redirect unrecognised paths to the 404 page via `functions.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854411f1adc8326acb697f11d5f128a