### PR TITLE
Fix language toggle and unify Chinese font

### DIFF
--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -173,10 +173,10 @@ function toggleLanguage() {
     const englishIcon = document.getElementById('language-english');
     const chineseIcon = document.getElementById('language-chinese');
 
-    // Determine if the current language is Chinese by checking the display style
-    const isChinese = chineseIcon.style.display === 'inline';
+    // Determine the current language from the body class
+    const isChinese = document.body.classList.contains('chinese');
 
-    // Toggle the display styles of the language icons
+    // Show the icon for the language the user can switch to
     englishIcon.style.display = isChinese ? 'inline' : 'none';
     chineseIcon.style.display = isChinese ? 'none' : 'inline';
 
@@ -218,9 +218,9 @@ function applyPreferences() {
     // Toggle sidebar images to match the theme
     toggleImagesForDarkMode();
 
-    // Update language icon visibility based on the current language
-    englishIcon.style.display = isChinese ? 'none' : 'inline';
-    chineseIcon.style.display = isChinese ? 'inline' : 'none';
+    // Update language icon visibility so the user sees the alternate option
+    englishIcon.style.display = isChinese ? 'inline' : 'none';
+    chineseIcon.style.display = isChinese ? 'none' : 'inline';
 
     // Apply translations and font for the stored preference
     applyTranslations(isChinese ? 'chinese' : 'english');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -88,7 +88,8 @@
 /* ============================ */
 
 .chinese {
-    --font-family-base: var(--font-family-handwritten);
+    /* Use the standard serif font for both languages */
+    --font-family-base: 'Noto Serif SC', serif;
 }
 
 /* ============================ */


### PR DESCRIPTION
## Summary
- ensure Chinese version uses standard font
- show language toggle icon for the *other* language to switch to

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685447def93083269332e010ce851f6c