### PR TITLE
Highlight active sidebar link

### DIFF
--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -222,12 +222,43 @@ function loadSidebar() {
                 console.warn('Sidebar placeholder not found.');
             }
 
+            // Highlight the navigation item matching the current page
+            highlightActiveNav();
+
             // Initialize IntersectionObserver for sidebar height adjustment
             initializeSidebarObserver();
         })
         .catch(error => {
             console.error('Error loading sidebar:', error);
         });
+}
+
+/**
+ * Adds an 'active' class to the sidebar navigation item that
+ * corresponds to the current page path.
+ */
+function highlightActiveNav() {
+    const path = window.location.pathname.replace(/^\//, '').toLowerCase();
+
+    let navId = '';
+    if (path === '' || path === 'index.html') {
+        navId = 'nav-home';
+    } else if (path.startsWith('projects')) {
+        navId = 'nav-projects';
+    } else if (path.startsWith('writings')) {
+        navId = 'nav-writings';
+    } else if (path.startsWith('publications')) {
+        navId = 'nav-publications';
+    } else if (path.startsWith('resume')) {
+        navId = 'nav-resume';
+    }
+
+    if (navId) {
+        const navLink = document.getElementById(navId);
+        if (navLink && navLink.parentElement) {
+            navLink.parentElement.classList.add('active');
+        }
+    }
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -290,6 +290,12 @@ a:focus {
     transition: background-color 0.3s, color 0.3s; /* Kept transitions for hover effects */
 }
 
+#sidebar-navbar li.active,
+#sidebar-navbar li.active a {
+    background-color: var(--hover-color);
+    font-weight: bold;
+}
+
 /* --- Sidebar Logos --- */
 #sidebar-logos {
     display: flex;


### PR DESCRIPTION
## Summary
- detect current path and mark sidebar nav item with `active` class
- style `.active` nav items so they're easy to spot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68558a1c2e488326850af7c226216c93