### PR TITLE
Update GitHub commit API URL

### DIFF
--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -24,7 +24,8 @@ document.addEventListener("DOMContentLoaded", () => {
 // Constants for GitHub API
 const GITHUB_USERNAME = 'Adam-R-Lawrence'; // Replace with your GitHub username
 const GITHUB_REPO = 'Holm';               // Replace with your repository name
-const commitsApiUrl = `https://api.github.com/repos/${GITHUB_USERNAME}/${GITHUB_REPO}/commits`;
+// Limit results to the most recent commit to minimize payload size
+const commitsApiUrl = `https://api.github.com/repos/${GITHUB_USERNAME}/${GITHUB_REPO}/commits?per_page=1`;
 
 
 // Cache for fetched translation data


### PR DESCRIPTION
## Summary
- limit GitHub API request to a single commit

## Testing
- `node -e "fetch('https://api.github.com/repos/Adam-R-Lawrence/Holm/commits?per_page=1').then(res=>res.json()).then(data=>{console.log(Array.isArray(data), data.length);}).catch(err=>console.error('fetch error',err));"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68558a268e84832692f447a8e4558f71