### PR TITLE
Inject analytics via JS

### DIFF
--- a/commonDivsHTML/analytics.html
+++ b/commonDivsHTML/analytics.html
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-4PHH3RMS01');
+</script>

--- a/index.html
+++ b/index.html
@@ -3,19 +3,6 @@
 
 <head>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <title>Adam Lawrence</title>

--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -334,6 +334,26 @@ function loadContentHeader() {
 }
 
 /**
+ * Loads the Google Analytics script block and inserts it into the page head.
+ * @returns {Promise<void>}
+ */
+function loadAnalytics() {
+    return fetch('/commonDivsHTML/analytics.html')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to load analytics.html');
+            }
+            return response.text();
+        })
+        .then(data => {
+            document.head.insertAdjacentHTML('afterbegin', data);
+        })
+        .catch(error => {
+            console.error('Error loading analytics:', error);
+        });
+}
+
+/**
  * Displays the last updated date based on the latest GitHub commit.
  * Utilizes caching to minimize API requests.
  */
@@ -573,6 +593,9 @@ function loadWritingsData() {
  */
 async function initialize() {
     try {
+        // Load Google Analytics snippet
+        await loadAnalytics();
+
         // Load footer first to ensure it's available for the sidebar observer
         await loadFooter();
 

--- a/projects.html
+++ b/projects.html
@@ -2,15 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adam Lawrence - Projects</title>

--- a/projects/Ostium.html
+++ b/projects/Ostium.html
@@ -2,15 +2,6 @@
 <html lang="en">
 <head>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adam Lawrence - Torrentem</title>

--- a/projects/Torrentem.html
+++ b/projects/Torrentem.html
@@ -2,15 +2,6 @@
 <html lang="en">
 <head>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adam Lawrence - Torrentem</title>

--- a/projects/Vadum.html
+++ b/projects/Vadum.html
@@ -2,15 +2,6 @@
 <html lang="en">
 <head>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adam Lawrence - Torrentem</title>

--- a/publications.html
+++ b/publications.html
@@ -3,15 +3,6 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-
-            gtag('config', 'G-4PHH3RMS01');
-        </script>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Adam Lawrence - Writings</title>

--- a/resume.html
+++ b/resume.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Resume</title>

--- a/writings/numerical_modelling_of_photopolymerization.html
+++ b/writings/numerical_modelling_of_photopolymerization.html
@@ -2,15 +2,6 @@
 <html lang="en">
 <head>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PHH3RMS01"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-4PHH3RMS01');
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adam Lawrence - Torrentem</title>


### PR DESCRIPTION
## Summary
- add `commonDivsHTML/analytics.html` containing the Google Analytics script
- fetch analytics snippet in `initialize()` via new `loadAnalytics()`
- insert analytics into `<head>` dynamically
- remove the old inline analytics from individual HTML files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68558a39db188326919e4abe7ece6646