### PR TITLE
Add year filter for writings

### DIFF
--- a/data/writings.json
+++ b/data/writings.json
@@ -3,6 +3,7 @@
     "title": "Numerical Modelling of Photopolymerization",
     "date": "2025-03-18",
     "summary": "Computational modelling approaches developed for the NIST 2025 Benchmark competition",
-    "link": "writings/numerical_modelling_of_photopolymerization.html"
+    "link": "writings/numerical_modelling_of_photopolymerization.html",
+    "year": "2025"
   }
 ]

--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -502,6 +502,7 @@ function loadPublicationsData() {
  */
 function loadWritingsData() {
     const directory = document.getElementById('writings-directory');
+    const filterContainer = document.getElementById('writing-filter-controls');
     if (!directory) {
         return; // Exit if not on the writings page
     }
@@ -515,9 +516,14 @@ function loadWritingsData() {
         })
         .then(writings => {
             directory.innerHTML = '';
+
+            const items = [];
             writings.forEach(writing => {
                 const item = document.createElement('div');
                 item.className = 'writing-item';
+                if (writing.year) {
+                    item.dataset.year = writing.year;
+                }
 
                 const content = document.createElement('div');
                 content.className = 'writing-content';
@@ -562,7 +568,35 @@ function loadWritingsData() {
                 item.appendChild(content);
                 item.appendChild(meta);
                 directory.appendChild(item);
+                items.push(item);
             });
+
+            if (filterContainer) {
+                const years = [...new Set(writings.map(w => w.year).filter(Boolean))];
+                const select = document.createElement('select');
+                select.id = 'year-filter';
+
+                const allOption = document.createElement('option');
+                allOption.value = 'all';
+                allOption.textContent = 'All Years';
+                select.appendChild(allOption);
+
+                years.forEach(year => {
+                    const opt = document.createElement('option');
+                    opt.value = year;
+                    opt.textContent = year;
+                    select.appendChild(opt);
+                });
+
+                filterContainer.appendChild(select);
+
+                select.addEventListener('change', () => {
+                    const val = select.value;
+                    items.forEach(item => {
+                        item.style.display = (val === 'all' || item.dataset.year === val) ? 'flex' : 'none';
+                    });
+                });
+            }
         })
         .catch(error => console.error('Error loading writings:', error));
 }

--- a/writings.html
+++ b/writings.html
@@ -33,6 +33,8 @@
 
                 <h1 id="writings-header">Writings</h1>
 
+                <div id="writing-filter-controls"></div>
+
                 <div id="writings-directory">
                     <!-- Entries populated by functions.js -->
                 </div>


### PR DESCRIPTION
## Summary
- add year data to writing entry
- generate dropdown controls for filtering writings by year
- include filter container in the writings page

## Testing
- `jq . data/writings.json`

------
https://chatgpt.com/codex/tasks/task_e_68558a474d6c8326b352b4b2e6b18027