### PR TITLE
Add system theme detection

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -10,3 +10,4 @@ ffmpeg -i input.webp -vf "scale=iw*0.378:ih*0.378" -compression_level 6 -q:v 50 
 ffmpeg -i input.webp -vf "scale=WIDTH:HEIGHT" -compression_level 6 -q:v 50 output.webp
 
 ffmpeg -i input.png output.webp
+- If no theme is saved, pages check `prefers-color-scheme` to choose dark or light mode by default.

--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -659,6 +659,16 @@ function loadWritingsData() {
  */
 async function initialize() {
     try {
+        // Set initial theme based on system preference if no saved value exists
+        if (!localStorage.getItem('theme')) {
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (prefersDark) {
+                document.body.classList.add('dark-theme');
+            } else {
+                document.body.classList.remove('dark-theme');
+            }
+        }
+
         // Load Google Analytics snippet
         await loadAnalytics();
 


### PR DESCRIPTION
## Summary
- auto-apply dark or light theme on page load when there is no saved preference
- document this new behavior in TODO list

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855baa2e7e88326bec7d4a01a3561c6