### PR TITLE
Increase spacing between text and images

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -121,6 +121,13 @@ a:focus {
     color: var(--link-hover-color);
 }
 
+/* Standard spacing for images */
+img {
+    display: block;
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+}
+
 /*       SCROLLBAR STYLING     */
 /* ============================ */
 

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -30,7 +30,7 @@
     display: block;
     width: 100%;
     border-radius: 1em;
-    margin-bottom: 1.2em;
+    margin: 1.5em 0;
 }
 
 /* --- Paragraphs in Main Content --- */
@@ -110,6 +110,7 @@
 .project-item img {
     width: 100%;
     height: auto;
+    margin: 0;
 }
 
 .project-item h2 {
@@ -506,6 +507,11 @@ footer p {
         grid-template-columns: 1fr;
         gap: 20px;
     }
+}
+
+/* Gallery collage images should not have extra spacing */
+.collage-row img {
+    margin: 0;
 }
 
 /* ============================ */

--- a/styles/lightbox.css
+++ b/styles/lightbox.css
@@ -21,6 +21,7 @@ video.lightbox-content {
     max-width: 90%;
     max-height: 90%;
     box-sizing: border-box;
+    margin: 0;
 }
 
 /* Close Button */

--- a/styles/scss/_base.scss
+++ b/styles/scss/_base.scss
@@ -85,6 +85,12 @@ a:focus {
   color: var(--link-hover-color);
 }
 
+/* Standard spacing for images */
+img {
+  display: block;
+  margin: 1.5em 0;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 12px;

--- a/styles/scss/_layout.scss
+++ b/styles/scss/_layout.scss
@@ -52,7 +52,7 @@
     display: block;
     width: 100%;
     border-radius: 1em;
-    margin-bottom: 1.2em;
+    margin: 1.5em 0;
 }
 
 /* --- Paragraphs in Main Content --- */
@@ -132,6 +132,7 @@
 .project-item img {
     width: 100%;
     height: auto;
+    margin: 0;
 }
 
 .project-item h2 {
@@ -521,6 +522,11 @@ footer p {
         grid-template-columns: 1fr;
         gap: 20px;
     }
+}
+
+/* Gallery collage images should not have extra spacing */
+.collage-row img {
+    margin: 0;
 }
 
 /* ============================ */

--- a/styles/scss/_sidebar.scss
+++ b/styles/scss/_sidebar.scss
@@ -172,6 +172,7 @@
     width: auto;
     height: auto;
     vertical-align: middle;
+    margin: 0;
 }
 
 /* --- Sidebar Logos Hover Effect --- */

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -172,6 +172,7 @@
     width: auto;
     height: auto;
     vertical-align: middle;
+    margin: 0;
 }
 
 /* --- Sidebar Logos Hover Effect --- */

--- a/styles/styles.min.css
+++ b/styles/styles.min.css
@@ -76,6 +76,12 @@ a:hover, a:focus {
     color: var(--link-hover-color);
 }
 
+img {
+    display: block;
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+}
+
 /* ============================ */ /* LAYOUT */ /* ============================ */ /* --- Wrapper --- */
 .wrapper {
     display: flex;
@@ -254,6 +260,7 @@ a:hover, a:focus {
     width: auto;
     height: auto;
     vertical-align: middle;
+    margin: 0;
 }
 
 /* --- Sidebar Logos Hover Effect --- */
@@ -288,7 +295,7 @@ a:hover, a:focus {
     display: block;
     width: 100%;
     border-radius: 1em;
-    margin-bottom: 1.2em;
+    margin: 1.5em 0;
 }
 
 /* --- Paragraphs in Main Content --- */
@@ -358,6 +365,7 @@ a:hover, a:focus {
 .project-item img {
     width: 100%;
     height: auto;
+    margin: 0;
 }
 
 .project-item h2 { /* clamp(MIN, preferred, MAX): - MIN: 1.5em - preferred: 5vw - MAX: 2.5em */
@@ -780,6 +788,7 @@ pre code {
 .collage-row img {
     width: 48%; /* Adjust width to ensure two images fit side by side */
     height: auto;
+    margin: 0;
 }
 
 .gallery.original-image {


### PR DESCRIPTION
## Summary
- add global `img` spacing rule
- update content image styles to use uniform margins
- prevent extra margins for project previews, gallery collages and sidebar logos
- ensure lightbox images keep zero margin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ffa3c3788326b31db1f2e4fe678d