### PR TITLE
Fix sidebar overflow on mobile

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -452,12 +452,19 @@ screen and (pointer: coarse) {
     }
 
     /* --- Sidebar Navbar --- */
+    #sidebar-navbar {
+        flex-grow: 0;        /* Let content define the height */
+    }
+
     #sidebar-navbar ul {
         flex-direction: column;
+        height: auto;        /* Allow list to size naturally */
+        justify-content: flex-start;
     }
 
     #sidebar-navbar li {
         padding: 10px 0;
+        flex-grow: 0;        /* Prevent items from stretching on mobile */
     }
 
     /* --- Headings Alignment --- */

--- a/styles/scss/_layout.scss
+++ b/styles/scss/_layout.scss
@@ -467,12 +467,19 @@ screen and (pointer: coarse) {
     }
 
     /* --- Sidebar Navbar --- */
+    #sidebar-navbar {
+        flex-grow: 0;        /* Let content define the height */
+    }
+
     #sidebar-navbar ul {
         flex-direction: column;
+        height: auto;        /* Allow list to size naturally */
+        justify-content: flex-start;
     }
 
     #sidebar-navbar li {
         padding: 10px 0;
+        flex-grow: 0;        /* Prevent items from stretching on mobile */
     }
 
     /* --- Headings Alignment --- */

--- a/styles/styles.min.css
+++ b/styles/styles.min.css
@@ -649,12 +649,19 @@ header a:hover, header a:focus {
     }
 
     /* --- Sidebar Navbar --- */
+    #sidebar-navbar {
+        flex-grow: 0;
+    }
+
     #sidebar-navbar ul {
         flex-direction: column;
+        height: auto;
+        justify-content: flex-start;
     }
 
     #sidebar-navbar li {
         padding: 10px 0;
+        flex-grow: 0;
     }
 
     /* --- Headings Alignment --- */


### PR DESCRIPTION
## Summary
- prevent sidebar nav items from stretching on narrow screens
- let mobile sidebar height adjust to fit content

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a142f167c83268ede33906765145a