### PR TITLE
Fix sidebar overflow on small screens

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -437,8 +437,8 @@ screen and (pointer: coarse) {
         gap: 1em;
         border-radius: 0em;
 
-        /* Let the sidebar expand as needed: */
-        height: auto;
+        /* Sidebar should occupy full viewport height on mobile */
+        height: 100vh;
         max-height: none;
     }
 

--- a/styles/scss/_layout.scss
+++ b/styles/scss/_layout.scss
@@ -452,8 +452,8 @@ screen and (pointer: coarse) {
         gap: 1em;
         border-radius: 0em;
 
-        /* Let the sidebar expand as needed: */
-        height: auto;
+        /* Sidebar should occupy full viewport height on mobile */
+        height: 100vh;
         max-height: none;
     }
 

--- a/styles/scss/_sidebar.scss
+++ b/styles/scss/_sidebar.scss
@@ -16,7 +16,7 @@
     border: 0.2em solid var(--border-color);
     border-radius: 1.5em;
     margin: 0.5em;
-    overflow-y: hidden;
+    overflow-y: auto;                /* Allow scrolling when content overflows */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle depth */
 
     display: flex;                     /* Make it a flex container */

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -16,7 +16,7 @@
     border: 0.2em solid var(--border-color);
     border-radius: 1.5em;
     margin: 0.5em;
-    overflow-y: hidden;
+    overflow-y: auto;                /* Allow scrolling when content overflows */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle depth */
 
     display: flex;                     /* Make it a flex container */

--- a/styles/styles.min.css
+++ b/styles/styles.min.css
@@ -120,7 +120,7 @@ img {
     border: 0.2em solid var(--border-color);
     border-radius: 1.5em;
     margin: 0.5em;
-    overflow-y: hidden;
+    overflow-y: auto; /* Allow scrolling when content overflows */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     display: flex; /* Make it a flex container */
     flex-direction: column; /* Align children vertically */
@@ -635,7 +635,7 @@ header a:hover, header a:focus {
         font-size: 1.05em;
         padding: 1em 0.5em 0.5em 1em;
         border-radius: 0em; /* Let the sidebar expand as needed: */
-        height: auto;
+        height: 100vh;
         max-height: none;
     }
 


### PR DESCRIPTION
## Summary
- allow sidebar scrolling when content overflows
- keep sidebar full height on mobile layouts

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a16bcd9d0832680c086c5274e362d