### PR TITLE
Fix theme toggle persistence on mobile

### DIFF
--- a/javascript/functions.js
+++ b/javascript/functions.js
@@ -170,8 +170,11 @@ async function applyPreferences() {
     const isChinese = localStorage.getItem('language') === 'chinese';
 
     // Apply saved theme preference
-    if (localStorage.getItem('theme') === 'dark') {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
         document.body.classList.add('dark-theme');
+    } else if (savedTheme === 'light') {
+        document.body.classList.remove('dark-theme');
     }
     const isDarkMode = document.body.classList.contains('dark-theme');
 


### PR DESCRIPTION
## Summary
- correctly remove `dark-theme` class when saved theme is light

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ad277cca483269bdf3ea8d6e0d060