### PR TITLE
Fix writings page layout on small screens

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -198,9 +198,8 @@
     border-radius: 5px;
     background-color: #e8f0fe;              /* Light blue background */
     text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;                    /* Allow titles to wrap on small screens */
+    overflow-wrap: anywhere;                /* Break long words when necessary */
     /* Transition removed to disable smooth color, background, and font-size changes on theme toggle */
 }
 
@@ -433,7 +432,8 @@ screen and (pointer: coarse) {
 
     /* --- Writings Directory --- */
     #writings-directory {
-        width: 90%;
+        width: 100%;
+        margin-left: 0;
     }
 
     #writings-directory .writing-item {
@@ -448,6 +448,10 @@ screen and (pointer: coarse) {
 
     #writing-filter-controls select {
         max-width: 100%;
+    }
+
+    #writing-filter-controls {
+        margin-left: 0;
     }
 
     /* --- Container Adjustments --- */

--- a/styles/scss/_layout.scss
+++ b/styles/scss/_layout.scss
@@ -221,9 +221,8 @@
     border-radius: 5px;
     background-color: #e8f0fe;              /* Light blue background */
     text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;                    /* Allow titles to wrap on small screens */
+    overflow-wrap: anywhere;                /* Break long words when necessary */
     /* Transition removed to disable smooth color, background, and font-size changes on theme toggle */
 }
 
@@ -449,7 +448,8 @@ screen and (pointer: coarse) {
 
     /* --- Writings Directory --- */
     #writings-directory {
-        width: 90%;
+        width: 100%;
+        margin-left: 0;
     }
 
     #writings-directory .writing-item {
@@ -464,6 +464,10 @@ screen and (pointer: coarse) {
 
     #writing-filter-controls select {
         max-width: 100%;
+    }
+
+    #writing-filter-controls {
+        margin-left: 0;
     }
 
     /* --- Container Adjustments --- */

--- a/styles/styles.min.css
+++ b/styles/styles.min.css
@@ -416,9 +416,8 @@ img {
     border-radius: 5px;
     background-color: #e8f0fe; /* Light blue background */
     text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis; /* Transition removed to disable smooth color, background, and font-size changes on theme toggle */
+    white-space: normal; /* Allow titles to wrap on small screens */
+    overflow-wrap: anywhere; /* Break long words when necessary */ /* Transition removed to disable smooth color, background, and font-size changes on theme toggle */
 }
 
 #writings-directory a:hover, #writings-directory a:focus {
@@ -616,7 +615,8 @@ header a:hover, header a:focus {
 @media screen and (max-width: 500px), screen and (max-height: 500px), screen and (pointer: none), screen and (pointer: coarse) {
     /* --- Writings Directory --- */
     #writings-directory {
-        width: 90%;
+        width: 100%;
+        margin-left: 0;
     }
 
     #writings-directory .writing-item {
@@ -631,6 +631,10 @@ header a:hover, header a:focus {
 
     #writing-filter-controls select {
         max-width:100%;
+    }
+
+    #writing-filter-controls {
+        margin-left: 0;
     }
 
     /* --- Container Adjustments --- */


### PR DESCRIPTION
## Summary
- allow writing titles to wrap to avoid overflow
- fix margins for writings directory and filter controls on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3368c2483268de3813663ece9b6